### PR TITLE
Rebase

### DIFF
--- a/frameworks/Java/greenlightning/pom.xml
+++ b/frameworks/Java/greenlightning/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.ociweb.gl.benchmark</groupId>
 	<artifactId>benchmark-test</artifactId>
-	<version>1.0.34</version> 
+	<version>1.0.35</version> 
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/frameworks/Java/greenlightning/src/main/java/com/ociweb/gl/benchmark/FrameworkTest.java
+++ b/frameworks/Java/greenlightning/src/main/java/com/ociweb/gl/benchmark/FrameworkTest.java
@@ -159,7 +159,7 @@ public class FrameworkTest implements GreenApp {
 	@Override
     public void declareConfiguration(GreenFramework framework) {
 		
-		framework.setDefaultRate(60_000L);			
+		framework.setDefaultRate(64_000L);			
 	
 		//for 14 cores this is expected to use less than 16G, must use next largest prime to ensure smaller groups are not multiples.
 		framework.useHTTP1xServer(bindPort, this::parallelBehavior) //standard auto-scale
@@ -168,8 +168,8 @@ public class FrameworkTest implements GreenApp {
     			 .setConcurrentChannelsPerDecryptUnit(concurrentWritesPerChannel)                //16K   14 bits
     	
     			 //NOTE: not sure this is optimal yet ...
-    			 .setConcurrentChannelsPerEncryptUnit(Math.max(1,concurrentWritesPerChannel/4))  //4K    
-    		//	 .setConcurrentChannelsPerEncryptUnit(concurrentWritesPerChannel)
+    			// .setConcurrentChannelsPerEncryptUnit(Math.max(1,concurrentWritesPerChannel/2))  //8K    
+    			 .setConcurrentChannelsPerEncryptUnit(concurrentWritesPerChannel)
     			 
     			 .disableEPoll()
  						 
@@ -229,9 +229,6 @@ public class FrameworkTest implements GreenApp {
 
 	public void parallelBehavior(GreenRuntime runtime) {
 
-
-		
-		
 		SimpleRest restTest = new SimpleRest(runtime, jsonMaxResponseCount, jsonMaxResponseSize);		
 		runtime.registerListener("Simple", restTest)
 		       .includeRoutes(Struct.PLAINTEXT_ROUTE, restTest::plainRestRequest)


### PR DESCRIPTION
* Adding GreenLightning

* fix missing quote

create object for json production

* turn off telemetry for default test

* allow any external domain or ip

* Update to next version and template construction

* Revert "Update to next version and template construction"

This reverts commit da4fbc3b085f6e3b3bb50283d4d6e79efffdd3bb.

* Revert "Revert "Update to next version and template construction""

This reverts commit eb05517a192554caec7c5f690eeaaab171a549b6.

* Revert "Update to next version and template construction"

This reverts commit da4fbc3b085f6e3b3bb50283d4d6e79efffdd3bb.

* fix host ip to 0.0.0.0 to take load

added database read tests

* response large enough for multi db

remove epoll, it was not helping

added required headers

* update list of which tests we have implmented

* removed unused dependency

* remove unrequired 16G memory grab to get past travis check.

* Update to next GL version to fix overload issue past 1.5M rps

Refine template method to remove dead argument

* simplify arg parse

fixed issue with multi db under heavy load

* updat to atomic int

* Removed support for MultiTest, not stable at this time.

* added clean for safety

* remove dead code

* remove old comments

* [ci fw-only Java/greenlightning]

added comment

* [ci fw-only Java/greenlightning]

Added tests for remaining multi, update and fortunes

* [ci fw-only Java/greenlightning]

disable update test, seems to be missing some writes.

* [ci fw-only Java/greenlightning]

re-test of DBUpdate

* [ci fw-only Java/greenlightning]

disabled multi and update while tracking issue

* fixed muti paylod response JSON dups.

* [ci fw-only Java/greenlightning]

narrow building

* [ci skip] update readme

* [ci fw-only Java/greenlightning]

Update to version supporting 0.0.0.0 wildcard host

* [ci fw-only Java/greenlightning]

explicit memory min/max setting instead of default

update to new maven for build

* lower required low end to 8G

* [ci fw-only Java/greenlightning]

dropped min to 6G

* [ci fw-only Java/greenlightning]

memory reduction, was using as much as 20G, paging may have slowed test

reduce pipe memory allocations

combined behaviors to reduce memory

reduce db inflight collection to reduce memory

* Revert "[ci fw-only Java/greenlightning]"

This reverts commit 47c351db1ddeb64e65801f15e3c4398d5eca84ad.

* [ci fw-only Java/greenlightning]

Was using 16-20G which may cause paging and slow results

Reduced Pipe lenghts

Reduced concurrent connections

Combined behaviors to reduce Pipe counts for more memory.

Lowered limit to 16G to know it is enforced.

* removed minimum required memory in docker file

* [ci fw-only Java/greenlightning]  Ready for merge

* [ci fw-only Java/greenlightning]

Lowering memory usage to 7G from 14G

Clean up design to be easier to read

* [ci fw-only Java/greenlightning]

Investigating pef issue, returned threads to normal priority

Reduce the new and ongoing network kernel calls

Tread Executor using hardcoded count instead of asking docker

* [ci fw-only Java/greenlightning]

remove dead code

* [ci fw-only Java/greenlightning]

Test CentOS runtime in container

Add minimal logging to track runtime issues

* Revert "[ci fw-only Java/greenlightning]"

This reverts commit 7119eaa0df0f10ac5d5d6aca4bd15e04bc89de32.

* [ci fw-only Java/greenlightning]

added centOS in container as test

added minimal logging to debug deployment

* [ci fw-only Java/greenlightning]

1G less, narrow test scope

* [ci fw-only Java/greenlightning]

streamline trie parser for headers etc

load balance based on primes to ensure even distribution

clean up ServerSocketWriter for larger blocks

Doubled ServerSocketWriters for greater volume.

* [ci fw-only Java/greenlightning]

Upgrade to Java 11 build and run pipeline

Update socket reader to optimize for greater volume

Upate pipe lengths to support greater volume

* [ci fw-only Java/greenlightning]

Double allowed limit on database connections

Bumped up to new version of GreenLightning

Doubled clock rate for reading new requests off socket

* missing version number restored

* [ci fw-only Java/greenlightning]

bump up in flight db count

* [ci fw-only Java/greenlightning]

Update to next version for larger read socket blocks

* [ci fw-only Java/greenlightning]

Bump up reactive pg client version to 11.1

Simplify build process

* [ci fw-only Java/greenlightning]

Bump up to next version

* [ci fw-only Java/greenlightning]

comments

* [ci fw-only Java/greenlightning]

update to new version of GL

update memory usage for volume

* [ci fw-only Java/greenlightning]

reduce DB calls in flight

* [ci fw-only Java/greenlightning]

bump up memory limit by 30%

* [ci fw-only Java/greenlightning]

outgoing buffers do not need to be that large reduced by 75%

* [ci fw-only Java/greenlightning]

Minimize open connections to save memory

* [ci fw-only Java/greenlightning]

next version of GL

bump up connections

* [ci fw-only Java/greenlightning]

update version

reduce memory per connection

reduce deep sleep

* Revert "[ci fw-only Java/greenlightning]"

This reverts commit f6f398f84f787b83c71d69d1087498d30b7e1bec.

* [ci fw-only Java/greenlightning]

next version

* [ci fw-only Java/greenlightning]

change memory usage to favor more connections

* update docker file for more memory

* update version

* [ci fw-only Java/greenlightning]

update memory limit

* Revert "[ci fw-only Java/greenlightning]"

This reverts commit 3a840590bd391a488244610dcbe9d61b1972577b.

* [ci fw-only Java/greenlightning]

limit selectors and increase tracks

* [ci fw-only Java/greenlightning]

update to new version

* [ci fw-only Java/greenlightning]

update version

* [ci fw-only Java/greenlightning]

update port

* [ci fw-only Java/greenlightning]

removed epoll

corrected pipe count

update version

* [ci fw-only Java/greenlightning]

update to next version fixing lock issue

testing direct memory pipe

* [ci fw-only Java/greenlightning]

record the network config data to the log

add more parallel pipelines for processing

fixed bug in db processing

udpate version

* [ci fw-only Java/greenlightning]

refine http router to load data quicker

update ver

create longer pipe lengths

* [ci fw-only Java/greenlightning]

simplify docker file

* [ci fw-only Java/greenlightning]

batch update after pulling each value individually

* [ci fw-only Java/greenlightning]

update the w var

* [ci fw-only Java/greenlightning]

update

* [ci fw-only Java/greenlightning]

update

* [ci fw-only Java/greenlightning]

next GL version, more output pipes.

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
